### PR TITLE
Set right find command for dreame vaccum

### DIFF
--- a/core/conf/dreamevacuum.json
+++ b/core/conf/dreamevacuum.json
@@ -206,7 +206,7 @@
             "subtype": "other",
             "isVisible": 1,
             "configuration": {
-                "request": "locate"
+                "request": "identify"
             }
         },
         {


### PR DESCRIPTION
Command to find the dreame vaccum is "identify" and not "locate"

<img width="515" alt="Capture d’écran 2024-05-16 à 10 16 58" src="https://github.com/Julien80/dreame/assets/14568237/2037beaf-60bf-4449-875d-ea2ea63239ba">
